### PR TITLE
Fix kubeadm provision for v1.11.1

### DIFF
--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -16,7 +16,7 @@
   register: kubelet_conf
 
 - name: Calculate kubeadm CA cert hash
-  shell: openssl x509 -pubkey -in {{ kube_config_dir }}/ssl/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
+  shell: openssl x509 -pubkey -in {{ kube_cert_dir }}/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //'
   register: kubeadm_ca_hash
   delegate_to: "{{ groups['kube-master'][0] }}"
   run_once: true

--- a/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
+++ b/roles/kubernetes/kubeadm/templates/kubeadm-client.conf.j2
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1alpha2
 kind: NodeConfiguration
 clusterName: {{ cluster_name }}
 discoveryFile: ""
-caCertPath: {{ kube_config_dir }}/ssl/ca.crt
+caCertPath: {{ kube_cert_dir }}/ca.crt
 discoveryToken: {{ kubeadm_tlsbootstraptoken }}
 tlsBootstrapToken: {{ kubeadm_tlsbootstraptoken }}
 token: {{ kubeadm_tlsbootstraptoken }}

--- a/roles/kubernetes/master/tasks/encrypt-at-rest.yml
+++ b/roles/kubernetes/master/tasks/encrypt-at-rest.yml
@@ -2,7 +2,7 @@
 - name: Write secrets for encrypting secret data at rest
   template:
     src: secrets_encryption.yaml.j2
-    dest: "{{ kube_config_dir }}/ssl/secrets_encryption.yaml"
+    dest: "{{ kube_cert_dir }}/secrets_encryption.yaml"
     owner: root
     group: "{{ kube_cert_group }}"
     mode: 0640

--- a/roles/kubernetes/master/tasks/kubeadm-setup.yml
+++ b/roles/kubernetes/master/tasks/kubeadm-setup.yml
@@ -62,7 +62,7 @@
   tags: facts
 
 - name: kubeadm | Copy etcd cert dir under k8s cert dir
-  command: "cp -TR {{ etcd_cert_dir }} {{ kube_config_dir }}/ssl/etcd"
+  command: "cp -TR {{ etcd_cert_dir }} {{ kube_cert_dir }}/etcd"
   changed_when: false
 
 - name: kubeadm | Create kubeadm config

--- a/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
+++ b/roles/kubernetes/master/templates/kubeadm-config.yaml.j2
@@ -8,7 +8,7 @@ auditPolicy:
   logDir: /var/log/kubernetes/audit
   logMaxAge: 2
   path: ""
-certificatesDir: {{ kube_config_dir }}/ssl
+certificatesDir: {{ kube_cert_dir }}
 clusterName: {{ cluster_name }}
 bootstrapTokens:
 - groups:
@@ -24,9 +24,9 @@ etcd:
 {% for endpoint in etcd_access_addresses.split(',') %}
   - {{ endpoint }}
 {% endfor %}
-  caFile: {{ kube_config_dir }}/ssl/etcd/ca.pem
-  certFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}.pem
-  keyFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}-key.pem
+  caFile: {{ kube_cert_dir }}/etcd/ca.pem
+  certFile: {{ kube_cert_dir }}/etcd/node-{{ inventory_hostname }}.pem
+  keyFile: {{ kube_cert_dir }}/etcd/node-{{ inventory_hostname }}-key.pem
 {% else %}
 etcd:
   external:
@@ -34,15 +34,15 @@ etcd:
 {% for endpoint in etcd_access_addresses.split(',') %}
       - {{ endpoint }}
 {% endfor %}
-      caFile: {{ kube_config_dir }}/ssl/etcd/ca.pem
-      certFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}.pem
-      keyFile: {{ kube_config_dir }}/ssl/etcd/node-{{ inventory_hostname }}-key.pem
+      caFile: {{ kube_cert_dir }}/etcd/ca.pem
+      certFile: {{ kube_cert_dir }}/etcd/node-{{ inventory_hostname }}.pem
+      keyFile: {{ kube_cert_dir }}/etcd/node-{{ inventory_hostname }}-key.pem
 {% endif %}
 networking:
   dnsDomain: {{ dns_domain }}
   serviceSubnet: {{ kube_service_addresses }}
   podSubnet: {{ kube_pods_subnet }}
-{% if cloud_provider is defined and cloud_provider != "gce" %}
+{% if cloud_provider is defined and cloud_provider != "gce"  and kube_version | version_compare('v1.11', '<') %}
 cloudProvider: {{ cloud_provider }}
 {% endif %}
 kubeProxy:
@@ -63,6 +63,9 @@ apiServerExtraArgs:
   insecure-bind-address: {{ kube_apiserver_insecure_bind_address }}
   insecure-port: "{{ kube_apiserver_insecure_port }}"
   apiserver-count: "{{ kube_apiserver_count }}"
+{% if cloud_provider is defined and cloud_provider != "gce"  and kube_version | version_compare('v1.11', '>=') %}
+  cloud-provider: {{ cloud_provider }}
+{% endif %}
 {% if kube_version | version_compare('v1.10', '<') %}
   admission-control: {{ kube_apiserver_admission_control | join(',') }}
 {% else %}
@@ -93,7 +96,7 @@ apiServerExtraArgs:
 {%   endif %}
 {% endif %}
 {% if kube_encrypt_secret_data %}
-  experimental-encryption-provider-config: {{ kube_config_dir }}/ssl/secrets_encryption.yaml
+  experimental-encryption-provider-config: {{ kube_cert_dir }}/secrets_encryption.yaml
 {% endif %}
   storage-backend: {{ kube_apiserver_storage_backend }}
 {% if kube_api_runtime_config is defined %}
@@ -107,6 +110,9 @@ controllerManagerExtraArgs:
   node-monitor-grace-period: {{ kube_controller_node_monitor_grace_period }}
   node-monitor-period: {{ kube_controller_node_monitor_period }}
   pod-eviction-timeout: {{ kube_controller_pod_eviction_timeout }}
+{% if cloud_provider is defined and cloud_provider != "gce"  and kube_version | version_compare('v1.11', '>=') %}
+  cloud-provider: {{ cloud_provider }}
+{% endif %}
 {% if kube_feature_gates %}
   feature-gates: {{ kube_feature_gates|join(',') }}
 {% endif %}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -115,7 +115,7 @@ spec:
     - --authorization-mode={{ authorization_modes|join(',') }}
 {% endif %}
 {% if kube_encrypt_secret_data %}
-    - --experimental-encryption-provider-config={{ kube_config_dir }}/ssl/secrets_encryption.yaml
+    - --experimental-encryption-provider-config={{ kube_cert_dir }}/secrets_encryption.yaml
 {% endif %}
 {% if kube_feature_gates %}
     - --feature-gates={{ kube_feature_gates|join(',') }}

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -106,7 +106,7 @@ spec:
 {% endfor %}
   - name: etc-kube-ssl
     hostPath:
-      path: "{{ kube_config_dir }}/ssl"
+      path: "{{ kube_cert_dir }}"
   - name: kubeconfig
     hostPath:
       path: "{{ kube_config_dir }}/kube-controller-manager-kubeconfig.yaml"

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -60,7 +60,7 @@ spec:
       name: {{ dir | regex_replace('^/(.*)$', '\\1' ) | regex_replace('/', '-') }}
       readOnly: true
 {% endfor %}
-    - mountPath: "{{ kube_config_dir }}/ssl"
+    - mountPath: "{{ kube_cert_dir }}"
       name: etc-kube-ssl
       readOnly: true
     - mountPath: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"
@@ -82,7 +82,7 @@ spec:
 {% endfor %}
   - name: etc-kube-ssl
     hostPath:
-      path: "{{ kube_config_dir }}/ssl"
+      path: "{{ kube_cert_dir }}"
   - name: kubeconfig
     hostPath:
       path: "{{ kube_config_dir }}/kube-scheduler-kubeconfig.yaml"

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -67,7 +67,7 @@
     - node
   with_items:
     - "{{ kube_config_dir }}"
-    - "{{ kube_config_dir }}/ssl"
+    - "{{ kube_cert_dir }}"
     - "{{ kube_manifest_dir }}"
     - "{{ kube_script_dir }}"
 


### PR DESCRIPTION
PR for support of cloudProvider flag for kubeadm enabled provisioning in K8s v1.11.1 (compatible with version kubeadm.k8s.io/v1alpha2)